### PR TITLE
fix(front): #298 add jest mocks and esmodules

### DIFF
--- a/packages/front/jest.config.js
+++ b/packages/front/jest.config.js
@@ -1,5 +1,7 @@
 const esModules = [
+  "@invertase/react-native-apple-authentication",
   "@react-native",
+  "@react-native-firebase",
   "react-native",
   "react-native-date-picker"
 ].join("|");

--- a/packages/front/jest.setup.ts
+++ b/packages/front/jest.setup.ts
@@ -6,6 +6,16 @@ import "@testing-library/jest-native/extend-expect";
 // the native animated module is missing
 jest.mock("react-native/Libraries/Animated/NativeAnimatedHelper");
 
+jest.mock("react-native/Libraries/EventEmitter/NativeEventEmitter");
+jest.mock("@react-native-google-signin/google-signin", () => ({
+  GoogleSignin: {
+    configure: jest.fn()
+  }
+}));
+jest.mock("@react-native-firebase/analytics", () => () => ({
+  logEvent: jest.fn()
+}));
+
 // Enable excluding hidden elements from the queries by default
 configure({
   defaultIncludeHiddenElements: false


### PR DESCRIPTION
- Add jest.mock for EventEmitter,  GoogleSignin and firebase/analytics
- Add apple-auth and firebase to esModules in jest config