### PR TITLE
ci(front): #394 add test to ci

### DIFF
--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -5,9 +5,10 @@ on:
       - main
     paths:
       - packages/front/**
+  workflow_dispatch:
 jobs:
-  lint:
-    name: Lint & Format
+  install:
+    name: Install dependencies
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -22,8 +23,30 @@ jobs:
       - name: Install front dependencies
         run: npm ci
 
+  lint:
+    name: Lint & Format
+    needs: install
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/front
+    steps:
+      - uses: actions/checkout@v3
+
       - name: Lint
         run: npm run lint:check
 
       - name: Format
         run: npm run format:check
+  test:
+    name: Test
+    needs: install
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/front
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Test
+        run: npm run test


### PR DESCRIPTION
- Move installation steps from job lint to its own job
- Add job test to run the npm test script