### PR TITLE
ci(front): #394 add test to ci

### DIFF
--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -7,8 +7,8 @@ on:
       - packages/front/**
   workflow_dispatch:
 jobs:
-  lint:
-    name: Lint & Format
+  install:
+    name: Install dependencies
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -23,8 +23,48 @@ jobs:
       - name: Install front dependencies
         run: npm ci
 
+      - name: Persist dependencies
+        uses: actions/upload-artifact@v2
+        with:
+          name: front-dependencies
+          path: |
+            packages/node_modules
+            packages/front/node_modules
+
+  lint:
+    name: Lint & Format
+    needs: install
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/front
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Restore dependencies
+        uses: actions/download-artifact@v2
+        with:
+          name: front-dependencies
+
       - name: Lint
         run: npm run lint:check
 
       - name: Format
         run: npm run format:check
+  test:
+    name: Test
+    needs: install
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/front
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Restore dependencies
+        uses: actions/download-artifact@v2
+        with:
+          name: front-dependencies
+
+      - name: Test
+        run: npm run test


### PR DESCRIPTION
- Move installation steps from job lint to its own job
- Add job test to run the npm test script