### PR TITLE
fix(front): #413 allow notifications while idle

### DIFF
--- a/packages/front/jest.setup.ts
+++ b/packages/front/jest.setup.ts
@@ -10,6 +10,12 @@ jest.mock("react-native/Libraries/EventEmitter/NativeEventEmitter");
 jest.mock("@notifee/react-native", () => ({
   cancelNotification: jest.fn(() => Promise.resolve()),
   createTriggerNotification: jest.fn(() => Promise.resolve()),
+  getNotificationSettings: jest.fn(() =>
+    Promise.resolve({
+      authorizationStatus: 0
+    })
+  ),
+  openAlarmPermissionSettings: jest.fn(),
   TriggerType: {
     TIMESTAMP: 0
   }

--- a/packages/front/src/utils/notifications/index.ts
+++ b/packages/front/src/utils/notifications/index.ts
@@ -25,6 +25,9 @@ const addNotification = (
       }
     },
     {
+      alarmManager: {
+        allowWhileIdle: true
+      },
       timestamp: Math.max(Date.now() + 1e3, time),
       type: TriggerType.TIMESTAMP
     }


### PR DESCRIPTION
- Trigger notifications with AlarmManager instead of WorkManager
- Allow notifications while in iddle/doze mode
- Mock Notifee's notification settings