### PR TITLE
feat(front): #465 ask user info on signup

### DIFF
--- a/packages/front/src/components/Modal/index.test.tsx
+++ b/packages/front/src/components/Modal/index.test.tsx
@@ -10,9 +10,8 @@ import { Modal } from ".";
 describe("Modal", () => {
   it("Render content", () => {
     expect.assertions(3);
-
     render(
-      <Modal title={"Congrats"} visible>
+      <Modal setVisible={jest.fn()} title={"Congrats"} visible>
         <Text>{"You're awesome"}</Text>
       </Modal>,
     );
@@ -23,6 +22,16 @@ describe("Modal", () => {
     expect(text).toBeOnTheScreen();
     const closeBtn = screen.queryByTestId("icon-times");
     expect(closeBtn).toBeOnTheScreen();
+  });
+
+  it("Hide close button", () => {
+    expect.assertions(1);
+    render(
+      <Modal title={"Congrats"} visible>
+        <Text>{"You're awesome"}</Text>
+      </Modal>,
+    );
+    expect(screen.queryByTestId("icon-times")).not.toBeOnTheScreen();
   });
 
   it("Be toggleable", async () => {

--- a/packages/front/src/components/Modal/index.tsx
+++ b/packages/front/src/components/Modal/index.tsx
@@ -30,9 +30,11 @@ const Modal = ({
         <View style={styles.container}>
           <View style={styles.header}>
             <Text variant={titleVar}>{title}</Text>
-            <Button onPress={handleClose}>
-              <Icon color={colors.BLACK} name={"times"} size={20} />
-            </Button>
+            {setVisible === undefined ? null : (
+              <Button onPress={handleClose}>
+                <Icon color={colors.BLACK} name={"times"} size={20} />
+              </Button>
+            )}
           </View>
           {children}
         </View>

--- a/packages/front/src/views/Landing/index.tsx
+++ b/packages/front/src/views/Landing/index.tsx
@@ -14,6 +14,7 @@ import { setDayTime } from "utils/date";
 import { useDB } from "utils/db";
 import { useScore } from "utils/engagement/score";
 import { NotificationsPermission } from "views/modals/NotificationsPermission";
+import { PatientInfoEdit } from "views/modals/PatientInfoEdit";
 
 import { DailyGoals } from "./DailyGoals";
 import { DailyHabits } from "./DailyHabits";
@@ -74,6 +75,14 @@ const Landing = ({
         />
         <NotificationsPermission />
       </View>
+      <PatientInfoEdit
+        data={userData?.basicInfo}
+        key={JSON.stringify(userData?.basicInfo)}
+        visible={
+          userData?.basicInfo?.id === undefined ||
+          userData?.basicInfo?.name === undefined
+        }
+      />
     </Screen>
   );
 };

--- a/packages/front/src/views/modals/PatientInfoEdit/index.tsx
+++ b/packages/front/src/views/modals/PatientInfoEdit/index.tsx
@@ -50,7 +50,9 @@ const PatientInfoEdit = ({
       />
       <Button
         disabled={
-          id === data?.id && name === data?.name && phone === data?.phone
+          (id === data?.id || id.length === 0) &&
+          (name === data?.name || name.length === 0) &&
+          phone === data?.phone
         }
         onPress={handleSave}
         style={{ marginTop: 8 }}

--- a/packages/front/src/views/modals/PatientInfoEdit/translations.ts
+++ b/packages/front/src/views/modals/PatientInfoEdit/translations.ts
@@ -12,7 +12,7 @@ const SPA = {
     placeholder: "312 456 7890",
   },
   save: "Guardar cambios",
-  title: "Editar datos básicos",
+  title: "Edita tus datos",
 };
 
 const t = (): typeof SPA => SPA;


### PR DESCRIPTION
- Show PatientInfoEdit when the user hasn't provided yet their id & name
- Disallow to save empty id or name
- Hide close button of Modal if the setVisible is not provided