### PR TITLE
feat(front): #470 allow to edit patient info

### DIFF
--- a/packages/web/src/utils/db/index.ts
+++ b/packages/web/src/utils/db/index.ts
@@ -61,8 +61,11 @@ const getDB = (uid: string): DBOperations => {
   return { addDoc, delDoc, getDocs, getUser, updateUser };
 };
 
-const useDB = (uid: string): DBOperations => {
+const useDB = (uid?: string): DBOperations | null => {
   return useMemo(() => {
+    if (uid === undefined) {
+      return null;
+    }
     return getDB(uid);
   }, [uid]);
 };

--- a/packages/web/src/views/Landing/Dashboard/index.test.tsx
+++ b/packages/web/src/views/Landing/Dashboard/index.test.tsx
@@ -6,7 +6,7 @@ import { t } from "./translations";
 
 describe("views/Landing/Dashboard", () => {
   beforeEach(() => {
-    render(<Dashboard uid={"-"} />);
+    render(<Dashboard />);
   });
 
   it("Show content", () => {

--- a/packages/web/src/views/Landing/Dashboard/index.tsx
+++ b/packages/web/src/views/Landing/Dashboard/index.tsx
@@ -1,11 +1,10 @@
 import React from "react";
 
-import { useDB } from "utils/db";
+import { useDBPatient } from "utils/contexts";
 
 import { LineChart } from "./LineChart";
 import { DashboardStat } from "./Stat";
 import { t } from "./translations";
-import type { DashboardProps } from "./types";
 
 const shortDate = (date = new Date()): string => {
   return date.toLocaleDateString(undefined, {
@@ -14,8 +13,8 @@ const shortDate = (date = new Date()): string => {
   });
 };
 
-const Dashboard = ({ uid }: DashboardProps): JSX.Element => {
-  const db = useDB(uid);
+const Dashboard = (): JSX.Element => {
+  const db = useDBPatient();
   const calms = db.getDocs("CalmActivities");
   const exercises = db.getDocs("Exercises");
   const foods = db.getDocs("FoodIntake");

--- a/packages/web/src/views/Landing/Dashboard/translations.ts
+++ b/packages/web/src/views/Landing/Dashboard/translations.ts
@@ -3,7 +3,7 @@ const SPA = {
   exercises: "Ejercicio",
   foodIntakes: "Alimentación",
   medicineIntakes: "Medicación",
-  records: (num: number) => `${num} registros`,
+  records: (num: number): string => `${num} registros`,
   score: "Puntaje",
   tensions: {
     diastolic: "Presión diastólica",

--- a/packages/web/src/views/Landing/Dashboard/types.ts
+++ b/packages/web/src/views/Landing/Dashboard/types.ts
@@ -1,5 +1,0 @@
-interface DashboardProps {
-  uid: string;
-}
-
-export type { DashboardProps };

--- a/packages/web/src/views/Landing/PatientInfo/index.test.tsx
+++ b/packages/web/src/views/Landing/PatientInfo/index.test.tsx
@@ -16,26 +16,4 @@ describe("views/Landing/PatientInfo", () => {
     expect(screen.queryByText(t().inactive)).toBeInTheDocument();
     expect(screen.queryByText(t().active)).not.toBeInTheDocument();
   });
-
-  it("Show data", () => {
-    expect.assertions(4);
-    const data = {
-      active: true,
-      basicInfo: {
-        id: "A2c",
-        name: "John Doe",
-        phone: "123 456 7890"
-      }
-    };
-    render(<PatientInfo data={data} />);
-    const texts = [
-      t().active,
-      data.basicInfo.id,
-      data.basicInfo.name,
-      data.basicInfo.phone
-    ];
-    texts.forEach((text) => {
-      expect(screen.queryByText(text)).toBeInTheDocument();
-    });
-  });
 });

--- a/packages/web/src/views/Landing/PatientInfo/index.tsx
+++ b/packages/web/src/views/Landing/PatientInfo/index.tsx
@@ -2,11 +2,11 @@ import React, { useReducer } from "react";
 
 import { Button } from "components/Button";
 import { Paper } from "components/Paper";
+import { useDBPatient } from "utils/contexts";
 import type { DBDisease } from "utils/db/types";
 
 import { EditPatientInfo } from "./Edit";
 import { t } from "./translations";
-import type { PatientInfoProps } from "./types";
 
 const styles = {
   col: "col-12 col-md-6 col-xl-3",
@@ -14,11 +14,13 @@ const styles = {
   val: "mb-0",
 };
 
-const PatientInfo = ({ data = {} }: PatientInfoProps): JSX.Element => {
+const PatientInfo = (): JSX.Element => {
   const [edit, toggleEdit] = useReducer((val) => !val, false);
+  const db = useDBPatient();
+  const data = db.getUser()?.data;
 
-  const diseases = Object.keys(data.diseases ?? {}).filter(
-    (key) => data.diseases?.[key as DBDisease],
+  const diseases = Object.keys(data?.diseases ?? {}).filter(
+    (key) => data?.diseases?.[key as DBDisease],
   ) as DBDisease[];
   return (
     <Paper>
@@ -26,14 +28,14 @@ const PatientInfo = ({ data = {} }: PatientInfoProps): JSX.Element => {
         <div className={styles.col}>
           <Paper>
             <p className={styles.key}>{t().id}</p>
-            <p className={styles.val}>{data.basicInfo?.id ?? t().undefined}</p>
+            <p className={styles.val}>{data?.basicInfo?.id ?? t().undefined}</p>
           </Paper>
         </div>
         <div className={styles.col}>
           <Paper>
             <p className={styles.key}>{t().name}</p>
             <p className={styles.val}>
-              {data.basicInfo?.name ?? t().undefined}
+              {data?.basicInfo?.name ?? t().undefined}
             </p>
           </Paper>
         </div>
@@ -41,7 +43,7 @@ const PatientInfo = ({ data = {} }: PatientInfoProps): JSX.Element => {
           <Paper>
             <p className={styles.key}>{t().phone}</p>
             <p className={styles.val}>
-              {data.basicInfo?.phone ?? t().undefined}
+              {data?.basicInfo?.phone ?? t().undefined}
             </p>
           </Paper>
         </div>
@@ -49,7 +51,7 @@ const PatientInfo = ({ data = {} }: PatientInfoProps): JSX.Element => {
           <Paper>
             <p className={styles.key}>{t().status}</p>
             <p className={styles.val}>
-              {data.active ? t().active : t().inactive}
+              {data?.active ? t().active : t().inactive}
             </p>
           </Paper>
         </div>
@@ -69,7 +71,12 @@ const PatientInfo = ({ data = {} }: PatientInfoProps): JSX.Element => {
       <Button className={"mt-3"} onClick={toggleEdit}>
         {t().edit}
       </Button>
-      <EditPatientInfo data={data} onClose={toggleEdit} visible={edit} />
+      <EditPatientInfo
+        data={data ?? {}}
+        key={JSON.stringify(data)}
+        onClose={toggleEdit}
+        visible={edit}
+      />
     </Paper>
   );
 };

--- a/packages/web/src/views/Landing/PatientInfo/types.ts
+++ b/packages/web/src/views/Landing/PatientInfo/types.ts
@@ -1,7 +1,0 @@
-import type { DBUser } from "utils/db/types";
-
-interface PatientInfoProps {
-  data?: DBUser;
-}
-
-export type { PatientInfoProps };

--- a/packages/web/src/views/Landing/index.tsx
+++ b/packages/web/src/views/Landing/index.tsx
@@ -2,6 +2,7 @@ import React, { useReducer, useState } from "react";
 
 import { Button } from "components/Button";
 import { signOut } from "utils/auth";
+import { DBPatientContext } from "utils/contexts";
 import { useDB } from "utils/db";
 
 import { Dashboard } from "./Dashboard";
@@ -13,20 +14,17 @@ import { t } from "./translations";
 
 const Landing = (): JSX.Element => {
   const [patient, setPatient] = useState<string>();
+  const db = useDB(patient);
   const [addMedicine, toggleAddMedicine] = useReducer((val) => !val, false);
 
-  const uid = patient ?? "-";
-  const db = useDB(uid);
-  const info = db.getUser()?.data;
-
   return (
-    <>
+    <DBPatientContext.Provider value={db}>
       <PatientSearch onFind={setPatient} />
       {patient === undefined ? null : (
         <>
-          <PatientInfo data={info} />
+          <PatientInfo />
           <hr />
-          <Dashboard uid={uid} />
+          <Dashboard />
           <hr />
           <p className={"h4 mb-2 mt-4"}>{t().medicineRecipes.title}</p>
           <Button onClick={toggleAddMedicine}>{t().medicineRecipes.add}</Button>
@@ -50,7 +48,7 @@ const Landing = (): JSX.Element => {
       >
         {t().signOut}
       </Button>
-    </>
+    </DBPatientContext.Provider>
   );
 };
 


### PR DESCRIPTION
- Edit useDB to allow undefined string but return null
- Replace usage of useDB by useDBPatient
- Don't pass down patient props to main sections
- Add save handling to PatientInfoEdit
- Disable edit without selecting diseases or making changes